### PR TITLE
feat(CacheableStrem) testable callbacks

### DIFF
--- a/mvp/build.gradle
+++ b/mvp/build.gradle
@@ -17,6 +17,9 @@ android {
             consumerProguardFiles 'proguard-consumer.pro'
         }
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
     defineOutputForAars(libraryVariants)
 }
 
@@ -32,6 +35,7 @@ dependencies {
     api "io.reactivex.rxjava2:rxjava:$rootProject.ext.rxjava2"
 
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
 }
 
 ext {

--- a/mvp/src/main/java/com/mandria/android/mvp/rx/CacheableStream.java
+++ b/mvp/src/main/java/com/mandria/android/mvp/rx/CacheableStream.java
@@ -14,11 +14,11 @@ import io.reactivex.functions.Consumer;
 /**
  * This class is used to cache a stream with its subscriber.
  */
-class CacheableStream<View, Result> {
+public class CacheableStream<View, Result> {
 
     private AbstractSubscriptionProxy<View, Result> mProxy;
 
-    private Consumer<BoundData<View, Result>> mConsumer;
+    private MVPConsumer<View, Result> mConsumer;
 
     /**
      * Constructor.
@@ -27,7 +27,7 @@ class CacheableStream<View, Result> {
      * @param view       Observable that emits the view.
      * @param consumer   Consumer to attach to the observable.
      */
-    CacheableStream(Observable<Result> observable, Observable<RxView<View>> view, Consumer<BoundData<View, Result>> consumer) {
+    CacheableStream(Observable<Result> observable, Observable<RxView<View>> view, MVPConsumer<View, Result> consumer) {
         mProxy = new ObservableSubscriptionProxy<>(observable, view);
         mConsumer = consumer;
     }
@@ -39,7 +39,7 @@ class CacheableStream<View, Result> {
      * @param view     Observable that emits the view.
      * @param consumer Consumer to attach to the observable.
      */
-    CacheableStream(Flowable<Result> flowable, Observable<RxView<View>> view, Consumer<BoundData<View, Result>> consumer) {
+    CacheableStream(Flowable<Result> flowable, Observable<RxView<View>> view, MVPConsumer<View, Result> consumer) {
         mProxy = new FlowableSubscriptionProxy<>(flowable, view);
         mConsumer = consumer;
     }
@@ -51,7 +51,7 @@ class CacheableStream<View, Result> {
      * @param view     Observable that emits the view.
      * @param consumer Consumer to attach to the observable.
      */
-    CacheableStream(Single<Result> single, Observable<RxView<View>> view, Consumer<BoundData<View, Result>> consumer) {
+    CacheableStream(Single<Result> single, Observable<RxView<View>> view, MVPConsumer<View, Result> consumer) {
         mProxy = new FlowableSubscriptionProxy<>(single.toFlowable(), view);
         mConsumer = consumer;
     }
@@ -63,7 +63,7 @@ class CacheableStream<View, Result> {
      * @param view        Observable that emits the view.
      * @param consumer    Consumer to attach to the observable.
      */
-    CacheableStream(Completable completable, Observable<RxView<View>> view, Consumer<BoundData<View, Result>> consumer) {
+    CacheableStream(Completable completable, Observable<RxView<View>> view, MVPConsumer<View, Result> consumer) {
         mProxy = new ObservableSubscriptionProxy<>(completable.<Result>toObservable(), view);
         mConsumer = consumer;
     }
@@ -75,7 +75,7 @@ class CacheableStream<View, Result> {
      * @param view     Observable that emits the view.
      * @param consumer Consumer to attach to the observable.
      */
-    CacheableStream(Maybe<Result> maybe, Observable<RxView<View>> view, Consumer<BoundData<View, Result>> consumer) {
+    CacheableStream(Maybe<Result> maybe, Observable<RxView<View>> view, MVPConsumer<View, Result> consumer) {
         mProxy = new ObservableSubscriptionProxy<>(maybe.toObservable(), view);
         mConsumer = consumer;
     }
@@ -99,5 +99,15 @@ class CacheableStream<View, Result> {
      */
     void cancel() {
         mProxy.cancel();
+    }
+
+    /**
+     * Test method is used only to return the consumer and offer the possibility to trigger
+     * callbacks
+     * @return the consumer
+     */
+    public MVPConsumer<View,Result> test() {
+        cancel();
+        return mConsumer;
     }
 }

--- a/mvp/src/main/java/com/mandria/android/mvp/rx/RxPresenter.java
+++ b/mvp/src/main/java/com/mandria/android/mvp/rx/RxPresenter.java
@@ -233,10 +233,11 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param <Result>    Result type of the observable.
      * @return The consumer to attach to the stream.
      */
-    private <Result> Consumer<BoundData<V, Result>> getCacheableStreamConsumer(@NonNull final String tag,
+    private <Result> MVPConsumer<V, Result> getCacheableStreamConsumer(@NonNull final String tag,
             @Nullable final OnNext<V, Result> onNext,
             @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
-        return new Consumer<BoundData<V, Result>>() {
+        return new MVPConsumer<V, Result>(onNext, onError, onCompleted) {
+
             @Override
             public void accept(@io.reactivex.annotations.NonNull BoundData<V, Result> rxViewResultBoundData) throws Exception {
                 V view = rxViewResultBoundData.getView();
@@ -348,7 +349,7 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onCompleted           OnCompleted action to call
      * @param <Result>              Result type of the observable.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Observable<Result> observable, boolean withDefaultSchedulers,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Observable<Result> observable, boolean withDefaultSchedulers,
             @Nullable final OnNext<V, Result> onNext, @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
 
         // noinspection unchecked
@@ -378,6 +379,7 @@ public class RxPresenter<V> extends Presenter<V> {
         if (cached != null) {
             cached.resume();
         }
+        return cached;
     }
 
     /**
@@ -396,9 +398,9 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onCompleted OnCompleted action to call
      * @param <Result>    Result type of the observable.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Observable<Result> observable, @Nullable final OnNext<V, Result> onNext,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Observable<Result> observable, @Nullable final OnNext<V, Result> onNext,
             @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
-        start(tag, observable, true, onNext, onError, onCompleted);
+        return start(tag, observable, true, onNext, onError, onCompleted);
     }
 
     /**
@@ -410,9 +412,9 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onError    OnError action to call
      * @param <Result>   Result type of the observable.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Observable<Result> observable, @Nullable final OnNext<V, Result> onNext,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Observable<Result> observable, @Nullable final OnNext<V, Result> onNext,
             @Nullable final OnError<V> onError) {
-        start(tag, observable, onNext, onError, null);
+        return start(tag, observable, onNext, onError, null);
     }
 
     /**
@@ -436,7 +438,7 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onCompleted           OnCompleted action to call
      * @param <Result>              Result type of the flowable.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Flowable<Result> flowable, boolean withDefaultSchedulers,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Flowable<Result> flowable, boolean withDefaultSchedulers,
             @Nullable final OnNext<V, Result> onNext, @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
 
         // noinspection unchecked
@@ -466,6 +468,7 @@ public class RxPresenter<V> extends Presenter<V> {
         if (cached != null) {
             cached.resume();
         }
+        return cached;
     }
 
     /**
@@ -484,9 +487,9 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onCompleted OnCompleted action to call
      * @param <Result>    Result type of the flowable.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Flowable<Result> flowable, @Nullable final OnNext<V, Result> onNext,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Flowable<Result> flowable, @Nullable final OnNext<V, Result> onNext,
             @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
-        start(tag, flowable, true, onNext, onError, onCompleted);
+        return start(tag, flowable, true, onNext, onError, onCompleted);
     }
 
     /**
@@ -498,9 +501,9 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onError  OnError action to call
      * @param <Result> Result type of the flowable.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Flowable<Result> flowable, @Nullable final OnNext<V, Result> onNext,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Flowable<Result> flowable, @Nullable final OnNext<V, Result> onNext,
             @Nullable final OnError<V> onError) {
-        start(tag, flowable, onNext, onError, null);
+        return start(tag, flowable, onNext, onError, null);
     }
 
     /**
@@ -524,7 +527,7 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onCompleted           OnCompleted action to call
      * @param <Result>              Result type of the single.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Single<Result> single, boolean withDefaultSchedulers,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Single<Result> single, boolean withDefaultSchedulers,
             @Nullable final OnNext<V, Result> onNext, @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
 
         // noinspection unchecked
@@ -554,6 +557,7 @@ public class RxPresenter<V> extends Presenter<V> {
         if (cached != null) {
             cached.resume();
         }
+        return cached;
     }
 
     /**
@@ -572,9 +576,9 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onCompleted OnCompleted action to call
      * @param <Result>    Result type of the single.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Single<Result> single, @Nullable final OnNext<V, Result> onNext,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Single<Result> single, @Nullable final OnNext<V, Result> onNext,
             @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
-        start(tag, single, true, onNext, onError, onCompleted);
+        return start(tag, single, true, onNext, onError, onCompleted);
     }
 
     /**
@@ -586,9 +590,9 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onError  OnError action to call
      * @param <Result> Result type of the single.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Single<Result> single, @Nullable final OnNext<V, Result> onNext,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Single<Result> single, @Nullable final OnNext<V, Result> onNext,
             @Nullable final OnError<V> onError) {
-        start(tag, single, onNext, onError, null);
+       return start(tag, single, onNext, onError, null);
     }
 
     /**
@@ -610,7 +614,7 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onError               OnError action to call
      * @param onCompleted           OnCompleted action to call
      */
-    public void start(@NonNull final String tag, @NonNull Completable completable, boolean withDefaultSchedulers,
+    public CacheableStream<V, Object> start(@NonNull final String tag, @NonNull Completable completable, boolean withDefaultSchedulers,
             @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
 
         // noinspection unchecked
@@ -640,6 +644,7 @@ public class RxPresenter<V> extends Presenter<V> {
         if (cached != null) {
             cached.resume();
         }
+        return cached;
     }
 
     /**
@@ -656,9 +661,9 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onError     OnError action to call
      * @param onCompleted OnCompleted action to call
      */
-    public void start(@NonNull final String tag, @NonNull Completable completable, @Nullable final OnError<V> onError,
+    public CacheableStream<V, Object>  start(@NonNull final String tag, @NonNull Completable completable, @Nullable final OnError<V> onError,
             @Nullable final OnCompleted<V> onCompleted) {
-        start(tag, completable, true, onError, onCompleted);
+        return start(tag, completable, true, onError, onCompleted);
     }
 
     /**
@@ -682,7 +687,7 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onCompleted           OnCompleted action to call
      * @param <Result>              Result type of the maybe.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Maybe<Result> maybe, boolean withDefaultSchedulers,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Maybe<Result> maybe, boolean withDefaultSchedulers,
             @Nullable final OnNext<V, Result> onNext, @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
 
         // noinspection unchecked
@@ -712,6 +717,7 @@ public class RxPresenter<V> extends Presenter<V> {
         if (cached != null) {
             cached.resume();
         }
+        return cached;
     }
 
     /**
@@ -730,9 +736,9 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onCompleted OnCompleted action to call
      * @param <Result>    Result type of the maybe.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Maybe<Result> maybe, @Nullable final OnNext<V, Result> onNext,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Maybe<Result> maybe, @Nullable final OnNext<V, Result> onNext,
             @Nullable final OnError<V> onError, @Nullable final OnCompleted<V> onCompleted) {
-        start(tag, maybe, true, onNext, onError, onCompleted);
+        return start(tag, maybe, true, onNext, onError, onCompleted);
     }
 
     /**
@@ -744,8 +750,8 @@ public class RxPresenter<V> extends Presenter<V> {
      * @param onError  OnError action to call
      * @param <Result> Result type of the maybe.
      */
-    public <Result> void start(@NonNull final String tag, @NonNull Maybe<Result> maybe, @Nullable final OnNext<V, Result> onNext,
+    public <Result> CacheableStream<V, Result> start(@NonNull final String tag, @NonNull Maybe<Result> maybe, @Nullable final OnNext<V, Result> onNext,
             @Nullable final OnError<V> onError) {
-        start(tag, maybe, onNext, onError, null);
+        return start(tag, maybe, onNext, onError, null);
     }
 }

--- a/mvp/src/test/java/com/mandria/android/mvp/ExampleUnitTest.java
+++ b/mvp/src/test/java/com/mandria/android/mvp/ExampleUnitTest.java
@@ -1,8 +1,13 @@
 package com.mandria.android.mvp;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -11,8 +16,42 @@ import static org.junit.Assert.*;
  */
 public class ExampleUnitTest {
 
-    @Test
-    public void addition_isCorrect() throws Exception {
-        assertEquals(4, 2 + 2);
+    private static final String TEST_VALUE = "testValue";
+    private static final String TEST_ERROR = "testError";
+    private static final Exception EXCEPTION = new Exception(TEST_ERROR);
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private View view;
+
+    @InjectMocks
+    private ExampleTestPresenter presenter;
+
+    @Before
+    public void setup() {
+        presenter = new ExampleTestPresenter();
     }
+
+    @Test
+    public void presenterOnNextTest() throws Exception {
+        presenter.startFoo().test().performOnNext(view, TEST_VALUE);
+        Mockito.verify(view).foo(TEST_VALUE);
+    }
+
+    @Test
+    public void presenterOnErrorTest() throws Exception {
+        presenter.startFoo().test().performOnError(view, EXCEPTION);
+        Mockito.verify(view).errorFoo(EXCEPTION.getMessage());
+    }
+
+    @Test
+    public void presenterOnCompleteTest() throws Exception {
+        presenter.startFoo().test().performOnComplete(view);
+        //In the presenter, the complete callback is null so nothing happens
+        Mockito.verify(view, Mockito.never()).errorFoo(EXCEPTION.getMessage());
+        Mockito.verify(view, Mockito.never()).foo(TEST_VALUE);
+    }
+
 }


### PR DESCRIPTION
 -> providing a refactoring so that start methods now provide the
CacheableStream that now contains a test() method cancelling the
subscription & returning a custom MVPConsumer allowing developers to
trigger the initial callbacks they provided.